### PR TITLE
[Edicion] Se agregan propiedades para reflejar correctamente el estado devuelvo por el SAT

### DIFF
--- a/Verify/Models/VerifyResponse.cs
+++ b/Verify/Models/VerifyResponse.cs
@@ -14,6 +14,7 @@
  * ============================================================================
  */
 
+using Fiscalapi.XmlDownloader.Common.Enums;
 using Fiscalapi.XmlDownloader.Common.Http;
 
 namespace Fiscalapi.XmlDownloader.Verify.Models;
@@ -42,4 +43,14 @@ public class VerifyResponse : BaseResponse
     /// Indicates if the request is ready for download
     /// </summary>
     public bool IsReadyToDownload => RequestStatus == RequestStatus.Terminada && InvoiceCount > 0;
+
+    /// <summary>
+    /// Operation status code from the SAT verification service
+    /// </summary>
+    public SatStatus SatStatusDownload { get; set; }
+
+    /// <summary>
+    /// Sat 'CodigoEstadoSolicitud' received from the service
+    /// </summary>
+    public string? SatStatusCodeDownload { get; set; }
 }

--- a/Verify/Models/VerifyResponse.cs
+++ b/Verify/Models/VerifyResponse.cs
@@ -45,12 +45,24 @@ public class VerifyResponse : BaseResponse
     public bool IsReadyToDownload => RequestStatus == RequestStatus.Terminada && InvoiceCount > 0;
 
     /// <summary>
+    /// Operation status code from the SAT service
+    /// </summary>
+    [Obsolete("Use RequestSatStatus instead.")]
+    public SatStatus SatStatus { get; set; } = new();
+
+    /// <summary>
+    /// Sat 'CodEstatus' received from the service
+    /// </summary>
+    [Obsolete("Use RequestSatStatusCode instead.")]
+    public string? SatStatusCode { get; set; } = new("");
+
+    /// <summary>
     /// Operation status code from the SAT verification service
     /// </summary>
-    public SatStatus SatStatusDownload { get; set; }
+    public SatStatus RequestSatStatus { get; set; }
 
     /// <summary>
     /// Sat 'CodigoEstadoSolicitud' received from the service
     /// </summary>
-    public string? SatStatusCodeDownload { get; set; }
+    public string? RequestSatStatusCode { get; set; }
 }

--- a/Verify/VerifyResponseService.cs
+++ b/Verify/VerifyResponseService.cs
@@ -58,9 +58,11 @@ public static class VerifyResponseService
          */
 
             //CodEstatus="5000"
+            // <Obsolete> No refleja correctamente el estatus de la ejecución de la acción Verify
             var codEstatus = envelope?.Body.VerifyDownloadRequestResponse
                 .VerifyDownloadRequestResult.CodEstatus;
 
+            // <Obsolete> No refleja correctamente el estatus de la ejecución de la acción Verify
             var status = !string.IsNullOrWhiteSpace(codEstatus)
                 ? codEstatus.ToEnumElement<SatStatus>()
                 : SatStatus.Unknown;

--- a/Verify/VerifyResponseService.cs
+++ b/Verify/VerifyResponseService.cs
@@ -65,6 +65,13 @@ public static class VerifyResponseService
                 ? codEstatus.ToEnumElement<SatStatus>()
                 : SatStatus.Unknown;
 
+            var codSatStatus = envelope?.Body.VerifyDownloadRequestResponse
+                .VerifyDownloadRequestResult.CodigoEstadoSolicitud;
+
+            var satStatus = !string.IsNullOrWhiteSpace(codSatStatus)
+                ? codSatStatus.ToEnumElement<SatStatus>()
+                : SatStatus.Unknown;
+
             // EstadoSolicitud="3"
             var estadoSolicitud = envelope?.Body.VerifyDownloadRequestResponse
                 .VerifyDownloadRequestResult.EstadoSolicitud;
@@ -96,6 +103,8 @@ public static class VerifyResponseService
                 Succeeded = true,
                 SatStatus = status,
                 SatStatusCode = status.ToEnumCode(),
+                SatStatusDownload = satStatus,
+                SatStatusCodeDownload = satStatus.ToEnumCode(),
                 SatMessage = mensaje,
                 RequestStatus = requestStatus,
                 InvoiceCount = invoiceCount,

--- a/Verify/VerifyResponseService.cs
+++ b/Verify/VerifyResponseService.cs
@@ -58,11 +58,9 @@ public static class VerifyResponseService
          */
 
             //CodEstatus="5000"
-            // <Obsolete> No refleja correctamente el estatus de la ejecución de la acción Verify
             var codEstatus = envelope?.Body.VerifyDownloadRequestResponse
                 .VerifyDownloadRequestResult.CodEstatus;
 
-            // <Obsolete> No refleja correctamente el estatus de la ejecución de la acción Verify
             var status = !string.IsNullOrWhiteSpace(codEstatus)
                 ? codEstatus.ToEnumElement<SatStatus>()
                 : SatStatus.Unknown;
@@ -105,8 +103,8 @@ public static class VerifyResponseService
                 Succeeded = true,
                 SatStatus = status,
                 SatStatusCode = status.ToEnumCode(),
-                SatStatusDownload = satStatus,
-                SatStatusCodeDownload = satStatus.ToEnumCode(),
+                RequestSatStatus = satStatus,
+                RequestSatStatusCode = satStatus.ToEnumCode(),
                 SatMessage = mensaje,
                 RequestStatus = requestStatus,
                 InvoiceCount = invoiceCount,
@@ -123,6 +121,8 @@ public static class VerifyResponseService
             SatMessage = $"StatusCode: {satResponse.HttpStatusCode} Message: {satResponse.ReasonPhrase}",
             RawRequest = satResponse.RawRequest,
             RawResponse = satResponse.RawResponse,
+            RequestSatStatus = SatStatus.Unknown,
+            RequestSatStatusCode = "UnknownError"
         };
     }
 }


### PR DESCRIPTION
Actualmente la verificación de un Request ID regresa un 5000(Estatus de la solicitud) y no el estatus del procesamiento de la misma petición. (Ver imagen)

En la imagen adjunta, se consultó un Request ID de una fecha donde no se generaron CFDIs (emitidos-cancelados, por ejemplo), por lo cual el código correcto es 5004 (Information not found) y al armar el VerifyResponse asigna el codStatus (5000) en lugar del valor real (5004).

Se proponen nuevas propiedades para reflejar el estatus de la acción, sin afectar las propiedades que se usan actualmente para este fin, para asegurar compatibilidad con legacy.

<img width="848" height="253" alt="image" src="https://github.com/user-attachments/assets/6224e54e-ea32-48dd-8e59-d45915171813" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification responses now include additional SAT download status fields (request status and request status code) for clearer verification outcomes.
  * Legacy-compatible, deprecated aliases were retained to preserve existing integrations.
* **Bug Fixes**
  * Status fields are now populated in both success and failure flows to ensure consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->